### PR TITLE
build(npm): fix npm run ios:dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "deploy:before": "build",
         "build:before": "build",
         "run:before": "build --dev",
+        "build --dev": "npm run build --dev",
         "ios:dev": "bnr ios:dev",
         "ios:release": "bnr ios:release",
         "ios:release:ci": "bnr ios:release:ci",


### PR DESCRIPTION
This may be a bit of a kludge but at least npm run ios:dev works again...

Closes #2 and #10